### PR TITLE
phpDoc: свойства класса, пустые строки

### DIFF
--- a/code-style-guide.md
+++ b/code-style-guide.md
@@ -384,9 +384,7 @@ class UserRepository
 {
     /**
      * Returns some data
-     *
      * @param int $id
-     *
      * @return array
      */
     public function getData(int $id): array
@@ -489,17 +487,15 @@ class OrderDto
 {
     /**
      * Id of order
-     * 
      * @var integer
      */
-    private $id;
+    private int $id;
 
     /**
      * Title of order
-     *
      * @var string
      */
-    private $title;
+    private string $title;
 
     /**
      * OrderDto constructor.
@@ -525,21 +521,18 @@ class OrderDto
 {
     /**
      * Id of order
-     * 
      * @var integer
      */
-    private $id;
+    private int $id;
 
     /**
      * Title of order
-     *
      * @var string
      */
-    private $title;
+    private string $title;
 
     /**
      * OrderDto constructor.
-     *
      * @param int $id
      * @param string $title
      */
@@ -601,29 +594,21 @@ class Order
 ```php
 class Order
 {
-    /**
-     * @var BookRepository $bookRepository
-     */
-    protected $bookRepository;
+    protected BookRepository $bookRepository;
 
     /**
      * Count of books
-     *
      * @var integer $attemptCount
      */
-    protected $count;
+    protected int $count;
 
-    /**
-     * @var UserRepository $userRepository
-     */
-    protected $userRepository;
+    protected UserRepository $userRepository;
 
     /**
      * Price of book
-     *
      * @var float $price
      */
-    protected $price;
+    protected float $price;
 }
 ```
 
@@ -631,29 +616,21 @@ class Order
 ```php
 class Order
 {
-    /**
-     * @var BookRepository $bookRepository
-     */
-    protected $bookRepository;
-    
-    /**
-     * @var UserRepository $userRepository
-     */
-    protected $userRepository;
+    protected BookRepository $bookRepository;
+
+    protected UserRepository $userRepository;
 
     /**
      * Count of books
-     *
      * @var integer $attemptCount
      */
-    protected $count;
+    protected int $count;
 
     /**
      * Price of book
-     *
      * @var float $price
      */
-    protected $price;
+    protected float $price;
 }
 ```
 
@@ -666,14 +643,12 @@ class User
 {
     /**
      * Name of user
-     *
      * @var string
      */
-    private $userName;
+    private string $userName;
 
     /**
      * Name getter
-     *
      * @return string
      */
     public function getUserName(): string
@@ -689,14 +664,12 @@ class User
 {
     /**
      * Name of user
-     *
      * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * Name getter
-     *
      * @return string
      */
     public function getName(): string
@@ -712,10 +685,7 @@ class User
 ```php
 class Order
 {
-    /**
-     * @var integer
-     */
-    public $id;
+    public int $id;
 }
 ```
 
@@ -723,16 +693,11 @@ class Order
 ```php
 class Order
 {
-    /**
-     * @var integer
-     */
-    private $id;
+    private int $id;
 
     /**
      * Order id setter
-     *
      * @param int $id
-     *
      * @return Order
      */
     public function setId(int $id): Order
@@ -744,7 +709,6 @@ class Order
 
     /**
      * Order id getter
-     *
      * @return int
      */
     public function getId(): int
@@ -815,21 +779,13 @@ $this
 ```php
 class Order
 {
-    /**
-     * @var integer
-     */
-    private $id;
+    private int $id;
     
-    /**
-     * @var string
-     */
-    private $title;
+    private string $title;
 
     /**
      * Order id setter
-     *
      * @param int $id
-     *
      * @return Order
      */
     public function setId(int $id): Order
@@ -841,9 +797,7 @@ class Order
 
     /**
      * Order title setter
-     *
      * @param string $title
-     *
      * @return Order
      */
     public function setTitle(string $title): Order
@@ -861,14 +815,10 @@ class Order
 ```php
 class Order
 {
-    /**
-     * @var integer
-     */
-    private $id;
+    private int $id;
     
     /**
      * Order id getter
-     *
      * @return int
      */
     public function getId(): int
@@ -882,14 +832,10 @@ class Order
 ```php
 class Order
 {
-   /**
-    * @var integer
-    */
-   private $id;
+   private int $id;
    
    /**
     * Order id getter
-    *
     * @return int
     */
    public function getId(): int
@@ -999,19 +945,12 @@ use App\Repository\OrderRepository;
 
 class PaymentOrder
 {
-    /**
-     * @var PaymentService
-     */
-    private $paymentService;
+    private PaymentService $paymentService;
     
-    /**
-     * @var OrderRepository
-     */
-    private $orderRepository;
+    private OrderRepository $orderRepository;
 
     /**
      * PaymentOrder constructor.
-     * 
      * @param PaymentService $paymentService
      * @param OrderRepository $orderRepository
      */
@@ -1023,9 +962,7 @@ class PaymentOrder
 
     /**
      * @param int $id
-     * 
      * @return bool
-     * 
      * @throws OrderAlreadyPayed
      * @throws OrderException
      * @throws OrderNotFoundException
@@ -1173,17 +1110,15 @@ class Order
 {
     /**
      * Order id
-     * 
      * @var int
      */
-    private $id;
+    private int $id;
 
     /**
      * Order title
-     * 
      * @var string
      */
-    private $title;
+    private string $title;
 }
 ```
 
@@ -1195,11 +1130,8 @@ class Order
 {
     /**
      * Order id setter
-     * 
      * @param int $id
-     * 
      * @return Order
-     * 
      * @throws \InvalidArgumentException
      */
     public function setId(int $id): Order
@@ -1225,7 +1157,7 @@ class Order
      * Current balance
      * @var float
      */
-    private $balance;
+    private float $balance;
 
     /**
      * Sends money between addresses
@@ -1257,20 +1189,16 @@ class Order
 {
     /**
      * Current balance
-     * 
      * @var float
      */
-    private $balance;
+    private float $balance;
 
     /**
      * Sends money between addresses
-     * 
      * @param string $from
      * @param string $to
      * @param float $amount
-     * 
      * @return bool
-     * 
      * @throws \InvalidArgumentException
      * @throws InvalidAmountException
      */

--- a/code-style-guide.md
+++ b/code-style-guide.md
@@ -384,8 +384,8 @@ class UserRepository
 {
     /**
      * Returns some data
-     * @param int $id
-     * @return array
+     * 
+     * @throws UserServiceException
      */
     public function getData(int $id): array
     {
@@ -487,21 +487,16 @@ class OrderDto
 {
     /**
      * Id of order
-     * @var integer
      */
     private int $id;
 
     /**
      * Title of order
-     * @var string
      */
     private string $title;
 
     /**
      * OrderDto constructor.
-     *
-     * @param int $id
-     * @param string $title
      */
     public function __construct(int $id, string $title)
     {
@@ -521,20 +516,16 @@ class OrderDto
 {
     /**
      * Id of order
-     * @var integer
      */
     private int $id;
 
     /**
      * Title of order
-     * @var string
      */
     private string $title;
 
     /**
      * OrderDto constructor.
-     * @param int $id
-     * @param string $title
      */
     public function __construct(int $id, string $title)
     {
@@ -598,7 +589,6 @@ class Order
 
     /**
      * Count of books
-     * @var integer $attemptCount
      */
     protected int $count;
 
@@ -606,7 +596,6 @@ class Order
 
     /**
      * Price of book
-     * @var float $price
      */
     protected float $price;
 }
@@ -622,13 +611,11 @@ class Order
 
     /**
      * Count of books
-     * @var integer $attemptCount
      */
     protected int $count;
 
     /**
      * Price of book
-     * @var float $price
      */
     protected float $price;
 }
@@ -643,13 +630,11 @@ class User
 {
     /**
      * Name of user
-     * @var string
      */
     private string $userName;
 
     /**
      * Name getter
-     * @return string
      */
     public function getUserName(): string
     {
@@ -664,13 +649,11 @@ class User
 {
     /**
      * Name of user
-     * @var string
      */
     private string $name;
 
     /**
      * Name getter
-     * @return string
      */
     public function getName(): string
     {
@@ -697,8 +680,6 @@ class Order
 
     /**
      * Order id setter
-     * @param int $id
-     * @return Order
      */
     public function setId(int $id): Order
     {
@@ -709,7 +690,6 @@ class Order
 
     /**
      * Order id getter
-     * @return int
      */
     public function getId(): int
     {
@@ -785,8 +765,6 @@ class Order
 
     /**
      * Order id setter
-     * @param int $id
-     * @return Order
      */
     public function setId(int $id): Order
     {
@@ -797,8 +775,6 @@ class Order
 
     /**
      * Order title setter
-     * @param string $title
-     * @return Order
      */
     public function setTitle(string $title): Order
     {
@@ -819,7 +795,6 @@ class Order
     
     /**
      * Order id getter
-     * @return int
      */
     public function getId(): int
     {
@@ -836,7 +811,6 @@ class Order
    
    /**
     * Order id getter
-    * @return int
     */
    public function getId(): int
    {
@@ -951,8 +925,6 @@ class PaymentOrder
 
     /**
      * PaymentOrder constructor.
-     * @param PaymentService $paymentService
-     * @param OrderRepository $orderRepository
      */
     public function __construct(PaymentService $paymentService, OrderRepository $orderRepository)
     {
@@ -961,8 +933,6 @@ class PaymentOrder
     }
 
     /**
-     * @param int $id
-     * @return bool
      * @throws OrderAlreadyPayed
      * @throws OrderException
      * @throws OrderNotFoundException
@@ -1110,19 +1080,18 @@ class Order
 {
     /**
      * Order id
-     * @var int
      */
     private int $id;
 
     /**
      * Order title
-     * @var string
      */
     private string $title;
 }
 ```
 
-- РЕКОМЕНДУЕТСЯ документировать методы класса. Документация ДОЛЖНА содержать краткое описание метода, список принимаемых аргументов, список выбрасываемых исключений и тип возвращаемого значения
+- РЕКОМЕНДУЕТСЯ документировать методы класса. Документация ДОЛЖНА содержать краткое описание метода, список 
+  выбрасываемых исключений и при необходимости список возвращаемых значений.
 
 Пример:
 ```php
@@ -1130,8 +1099,7 @@ class Order
 {
     /**
      * Order id setter
-     * @param int $id
-     * @return Order
+     *
      * @throws \InvalidArgumentException
      */
     public function setId(int $id): Order
@@ -1189,16 +1157,16 @@ class Order
 {
     /**
      * Current balance
+     *
      * @var float
      */
     private float $balance;
 
     /**
      * Sends money between addresses
-     * @param string $from
-     * @param string $to
-     * @param float $amount
+     *
      * @return bool
+     *
      * @throws \InvalidArgumentException
      * @throws InvalidAmountException
      */

--- a/code-style-guide.md
+++ b/code-style-guide.md
@@ -1090,27 +1090,51 @@ class Order
 }
 ```
 
-- РЕКОМЕНДУЕТСЯ документировать методы класса. Документация ДОЛЖНА содержать краткое описание метода, список 
-  выбрасываемых исключений и при необходимости список возвращаемых значений.
+- Документация ДОЛЖНА содержать список выбрасываемых исключений. РЕКОМЕНДУЕТСЯ краткое описание метода. Документация ДОЛЖНА содержать список аргументов и возвращаемых значений с указанием типа в случае если требуется добавить описание этим значениям или требуется специфические типы данных.
 
-Пример:
+Пример, когда не нужно указывать аннотации:
 ```php
-class Order
+class OrderRepository
+{
+    public function getById(int $id): Order
+    {
+        // ...
+    }
+}
+```
+
+Если мы хотим добавить смысла в параметры, то добавляем к ним комментарии.
+**Это утрированный пример. Так делать не надо!**
+```php
+class OrderRepository
 {
     /**
-     * Order id setter
+     * Get Order by id.
      *
-     * @throws \InvalidArgumentException
+     * @param int $id The order id we want to find
+     *
+     * @throws NotFoundException Throws exception if the order is not found by ID
+     *
+     * @return Order Return found Order
      */
-    public function setId(int $id): Order
+    public function getById(int $id): Order
     {
-        if ($id > 10) {
-            throw new \InvalidArgumentException('Order is does not correct');
-        }
-        
-        $this->id = $id;
-        
-        return $this;
+        // ...
+    }
+}
+
+```
+Если мы хотим вернуть специфичный тип данных такие как дженерики, типизированные массивы и т.д..
+https://phpstan.org/writing-php-code/phpdoc-types
+```php
+class OrderRepository
+{
+    /**
+     * @return Order[]
+     */
+    public function findByIds(int $id): array
+    {
+        // ...
     }
 }
 ```


### PR DESCRIPTION
1. phpDoc для свойств класса выглядят бессмысленными, если нет описания-комментария к свойствам. Сам тип свойства можно указать непосредственно через код
2. Пустые строки phpDoc имеют сомнительную пользу в плане улучшения читабельности кода. Хотя это и не регламентировано, но не думаю, что стоит это преподносить как пример для следования.