### PR TITLE
Отключение правила "simplified_if_return"

### DIFF
--- a/src/rules.php
+++ b/src/rules.php
@@ -13,7 +13,7 @@ return [
     'no_short_bool_cast' => true,
     'protected_to_private' => true,
     'self_static_accessor' => true,
-    'simplified_if_return' => true,
+    'simplified_if_return' => false, // Правило хорошее, но реализация плохая. Создает кучу мусора в коде
     'combine_nested_dirname' => true,
     'implode_call' => true,
     'lambda_not_used_import' => true,


### PR DESCRIPTION
Концептуально, правило хорошее, но реализация правила плохая.
https://cs.symfony.com/doc/rules/control_structure/simplified_if_return.html

Пример из документации *(обращаем внимание на пробелы перед точкой с запятой)*:
```diff
 <?php
-if ($foo) { return true; } return false;
+return (bool) ($foo)      ;
```

В реальных кейсах это выглядит значительно хуже
```diff
-        if (!$subscriptionInfo || !$subscriptionInfo->isValid()) {
-            return false;
-        }
-
-        return true;
+        return ! (!$subscriptionInfo || !$subscriptionInfo->isValid())
+
+
+
+         ;
```

```diff
        if ($this->isFpClient()) {
            // ...
        } elseif (empty($this->account['fp_tariff_id']) && empty($this->account['tariff_id'])) {
            return true;
-        } elseif (!empty($this->account['fp_tariff_id']) && !$this->isFpIntegrationEnabled()) {
-            return true;
-        }
+        } return (bool) (!empty($this->account['fp_tariff_id']) && !$this->isFpIntegrationEnabled())
+
+
+
+         ;
```

Вроде бы кейс подходящий, но результат не очень

```diff
-        if (!$this->isSuperAdmin()) {
-            return false;
-        }
-
-        return true;
+        return ! (!$this->isSuperAdmin())
+
+
+
+         ;
```